### PR TITLE
Updating base docker image to support additional dependencies required downstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,10 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: knapsack/knapsack-docker
-      
+          # will not tag as latest if published outside the main/master branch
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-# https://hub.docker.com/_/alpine/
-# fermium is node 14 LTS
-FROM node:fermium-alpine3.10
+FROM node:fermium-alpine3.14
 
 RUN apk add --no-cache \
-  bash \
-  php \
-  composer \
-  curl \
-  git \
-  openssh \
+ bash \
+ php \
+ composer \
+ curl \
+ git \
+ openssh \
+ ca-certificates \
+ openssl-dev \
+ wget \
+ python3 \
+ build-base \
+ vips-dev \
 && php --version && composer --version && node --version && yarn --version && npm --version
 
-CMD ["/bin/bash"]
-
+RUN mkdir -p /app && chown -R node /app
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh


### PR DESCRIPTION
updating docker metadata in action to not tag latest outside of main branch
updating node:fermium-alpine to 3.14
adding additional required dependencies